### PR TITLE
Additional features for node with yarn, tgz, version folders and broken links

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,11 +7,15 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+mkdir -p /usr/local/bin
+
 INSTALLER_PATH="/usr/local/bin/node_installer"
 
 cat > "$INSTALLER_PATH" << 'EOF'
 #!/bin/bash
 set -e
+
+mkdir -p /usr/local/lib/nodejs
 
 #Define functions
 print_help() {
@@ -26,6 +30,7 @@ clean_previous_installations() {
   rm -rf /usr/local/bin/node
   rm -rf /usr/local/bin/npm
   rm -rf /usr/local/lib/node_modules
+  rm -rf /usr/local/lib/nodejs/node-*
 }
 
 #Check positional arguments
@@ -103,10 +108,10 @@ else
 fi
 
 #Node installation
-cd /usr/local
-tar --strip-components 1 -xzf "$TMP_DIR"/"$TARGET".tar.gz
-rm -rf "$TMP_DIR"
-echo "Node version "$NODE" successfully installed"
+tar -xJf "$TMP_DIR"/"$TARGET".tar.gz -C /usr/local/lib/nodejs
+ln -s /usr/local/lib/nodejs/$TARGET/bin/node /usr/local/bin/node
+ln -s /usr/local/lib/nodejs/$TARGET/bin/npm /usr/local/bin/npm
+npm config set prefix /usr/local
 
 #Yarn installation
 while :; do

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 
+   exit 1
+fi
+
+INSTALLER_PATH="/usr/local/bin/node_installer"
+
+#mkdir -p /usr/local/bin
+
+cat > "$INSTALLER_PATH" << 'EOF'
+#!/bin/bash
+
+set -e
+
 print_help() {
 echo 'Usage as root or with sudo:
   node_installer 8.9.1 # this installs 8.9.1 version
@@ -101,3 +115,7 @@ while :; do
     esac
     shift
 done
+EOF
+
+chmod +x "$INSTALLER_PATH"
+echo "node_installer successfully installed"

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,9 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-mkdir -p /usr/local/bin
-
 INSTALLER_PATH="/usr/local/bin/node_installer"
+
+mkdir -p /usr/local/bin
 
 cat > "$INSTALLER_PATH" << 'EOF'
 #!/bin/bash
@@ -82,7 +82,16 @@ case $(uname) in
     exit 3
     ;;
 esac
-clean_previous_installations
+
+#Check for previous versions
+PREVIOUS_NODE=`ls -l /usr/local/lib/nodejs/ | awk '{print $9}'`
+if [[ ! -z "$PREVIOUS_NODE" ]] ; then
+  echo "Older node version exists, relinking to newer version after extraction"
+  rm /usr/local/bin/node
+  rm /usr/local/bin/npm
+fi
+
+
 echo "Downloading"
 export TMP_DIR=$( mktemp -d )
 cd "$TMP_DIR"

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ remove_broken_symlinks() {
 }
 remove_node_version() {
   CURRENT_NODE=`node --version`
-  NODE_DIR=`ls -lrt /usr/local/lib/nodejs | grep *$VERSION* | awk '{print $9}'`
+  NODE_DIR=`ls -lrt /usr/local/lib/nodejs | grep $VERSION | awk '{print $9}'`
   if [[ "$CURRENT_NODE" == v"$VERSION" ]] ; then
     echo "Requested to remove current node version"
     rm -rf /usr/local/lib/nodejs/node-v$VERSION-*

--- a/install.sh
+++ b/install.sh
@@ -86,14 +86,8 @@ else
   echo "tar corrupted or not downloaded properly"
   exit 6
 fi
-tar xzf "$TARGET".tar.gz
-rm -rf "$TARGET".tar.gz
-cp -r "$TARGET"/bin/node /usr/local/bin/
-mkdir -p /usr/local/lib
-cp -r "$TARGET"/lib/node_modules /usr/local/lib/
-cd /usr/local/bin
-ln -s ../lib/node_modules/npm/bin/npm-cli.js npm
-chmod +x node npm
+cd /usr/local
+tar --strip-components 1 -xzf "$TMP_DIR"/"$TARGET".tar.gz
 rm -rf "$TMP_DIR"
 echo "Node version "$NODE" successfully installed"
 

--- a/install.sh
+++ b/install.sh
@@ -96,10 +96,12 @@ esac
 
 #Check for previous versions and prepare for new installation
 PREVIOUS_NODE=`ls -l /usr/local/lib/nodejs/ | awk '{print $9}'`
-if [[ ! -z "$PREVIOUS_NODE" ]] ; then
+if [[ ! -z "$PREVIOUS_NODE" ]] && [[ -f /usr/local/bin/node ]] ; then
   echo "Older node version exists, relinking to newer version after extraction"
   rm /usr/local/bin/node
   rm /usr/local/bin/npm
+else
+  echo "Previous versions do not exist"
 fi
 
 echo "Downloading"

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,12 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+if [[ $# -gt 2 ]] ; then
+  echo "Script supports maximum two arguments"
+  print_help
+  exit 0
+fi
+
 if [[ "$1" == 'clean' ]] ; then
   clean_previous_installations
   exit 0

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,12 @@ clean_previous_installations() {
   rm -rf /usr/local/lib/nodejs/node-*
 }
 
+remove_broken_symlinks() {
+  find -L /usr/local/bin -maxdepth 1 -type l
+  find -L /usr/local/bin -maxdepth 1 -type l -exec rm -- {} +
+}
+
+
 #Check positional arguments
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root"
@@ -91,6 +97,7 @@ if [[ ! -z "$PREVIOUS_NODE" ]] ; then
   rm /usr/local/bin/npm
 fi
 
+
 echo "Downloading"
 export TMP_DIR=$( mktemp -d )
 cd "$TMP_DIR"
@@ -127,6 +134,7 @@ while :; do
         --yarn)
         echo "Installing yarn via npm"
         npm install -g yarn
+#        ln -s /usr/local/lib/nodejs/$TARGET/bin/yarn /usr/local/bin/yarn
         ;;
         *) break
     esac
@@ -135,7 +143,11 @@ done
 if [[ ! -z "$YARN" ]] ; then
   echo "Installing yarn via npm"
   npm install -g $YARN
+#  ln -s /usr/local/lib/nodejs/$TARGET/bin/yarn /usr/local/bin/yarn
 fi
+
+#Remove broken symlinks
+remove_broken_symlinks
 EOF
 
 chmod +x "$INSTALLER_PATH"

--- a/install.sh
+++ b/install.sh
@@ -96,3 +96,14 @@ ln -s ../lib/node_modules/npm/bin/npm-cli.js npm
 chmod +x node npm
 rm -rf "$TMP_DIR"
 echo "Node version "$NODE" successfully installed"
+
+while :; do
+    case $2 in
+        -y|--yarn)
+        echo "Installing yarn via npm"
+        npm install -g yarn
+        ;;
+        *) break
+    esac
+    shift
+done

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,6 @@ if [[ ! -z "$PREVIOUS_NODE" ]] ; then
   rm /usr/local/bin/npm
 fi
 
-
 echo "Downloading"
 export TMP_DIR=$( mktemp -d )
 cd "$TMP_DIR"

--- a/install.sh
+++ b/install.sh
@@ -2,20 +2,6 @@
 
 set -e
 
-if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root" 
-   exit 1
-fi
-
-INSTALLER_PATH="/usr/local/bin/node_installer"
-
-mkdir -p /usr/local/bin
-
-cat > "$INSTALLER_PATH" << 'EOF'
-#!/bin/bash
-
-set -e
-
 print_help() {
 echo 'Usage as root or with sudo:
   node_installer 8.9.1 # this installs 8.9.1 version
@@ -31,7 +17,7 @@ clean_previous_installations() {
 }
 
 if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root" 
+   echo "This script must be run as root"
    print_help
    exit 1
 fi
@@ -46,19 +32,26 @@ if [[ "$1" == 'help' ]] || [[ -z "$1" ]] ; then
   exit 0
 fi
 
-if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
-  echo "Please provide existing node version in 'x.y.z' format"
+if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ ! "$1" =~ v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Please provide existing node version in 'x.y.z' or v'x.y.z' format"
   exit 2
 fi
 
-NODE="$1"
+if [[ "$1" =~ v[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+  echo "node version in v'x.y.z' format"
+  NODE="$1"
+elif [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+  echo "node version in 'x.y.z' format"
+  NODE=v"$1"
+fi
+
 TARGET=
 case $(uname) in
   "Linux")
-    TARGET="node-v"$NODE"-linux-x64"
+    TARGET="node-"$NODE"-linux-x64"
     ;;
   "Darwin")
-    TARGET="node-v"$NODE"-darwin-x64"
+    TARGET="node-"$NODE"-darwin-x64"
     ;;
    *)
     echo "System not supported"
@@ -73,9 +66,9 @@ echo "Downloading"
 export TMP_DIR=$( mktemp -d )
 cd "$TMP_DIR"
 if `which wget > /dev/null` ; then
-  wget -q https://nodejs.org/dist/v"$NODE"/"$TARGET".tar.gz
+  wget -q https://nodejs.org/dist/"$NODE"/"$TARGET".tar.gz
 elif `which curl > /dev/null` ; then
-  curl -sS -o "$TARGET".tar.gz https://nodejs.org/dist/v"$NODE"/"$TARGET".tar.gz
+  curl -sS -o "$TARGET".tar.gz https://nodejs.org/dist/"$NODE"/"$TARGET".tar.gz
 else
   echo "wget or curl command not found"
   exit 4
@@ -103,7 +96,3 @@ ln -s ../lib/node_modules/npm/bin/npm-cli.js npm
 chmod +x node npm
 rm -rf "$TMP_DIR"
 echo "Node version "$NODE" successfully installed"
-EOF
-
-chmod +x "$INSTALLER_PATH"
-echo "node_installer successfully installed"

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ cat > "$INSTALLER_PATH" << 'EOF'
 #!/bin/bash
 set -e
 
-mkdir -p /usr/local/lib/nodejs
+mkdir -p /usr/local/lib/nodejs # For installation of multiple node versions inside
 
 #Define functions
 print_help() {
@@ -37,7 +37,6 @@ remove_broken_symlinks() {
   find -L /usr/local/bin -maxdepth 1 -type l
   find -L /usr/local/bin -maxdepth 1 -type l -exec rm -- {} +
 }
-
 
 #Check positional arguments
 if [[ $EUID -ne 0 ]]; then
@@ -89,14 +88,13 @@ case $(uname) in
     ;;
 esac
 
-#Check for previous versions
+#Check for previous versions and prepare for new installation
 PREVIOUS_NODE=`ls -l /usr/local/lib/nodejs/ | awk '{print $9}'`
 if [[ ! -z "$PREVIOUS_NODE" ]] ; then
   echo "Older node version exists, relinking to newer version after extraction"
   rm /usr/local/bin/node
   rm /usr/local/bin/npm
 fi
-
 
 echo "Downloading"
 export TMP_DIR=$( mktemp -d )
@@ -114,7 +112,7 @@ fi || {
   rm -rf "$TMP_DIR"
   exit 5
 }
-tar -tzf "$TARGET".tar.gz >/dev/null
+tar -tzf "$TARGET".tar.gz >/dev/null  # Test the tar file downloaded properly or not
 if [[ "$?" -eq 0 ]] ; then
   echo "Installing"
 else
@@ -134,7 +132,6 @@ while :; do
         --yarn)
         echo "Installing yarn via npm"
         npm install -g yarn
-#        ln -s /usr/local/lib/nodejs/$TARGET/bin/yarn /usr/local/bin/yarn
         ;;
         *) break
     esac
@@ -143,7 +140,6 @@ done
 if [[ ! -z "$YARN" ]] ; then
   echo "Installing yarn via npm"
   npm install -g $YARN
-#  ln -s /usr/local/lib/nodejs/$TARGET/bin/yarn /usr/local/bin/yarn
 fi
 
 #Remove broken symlinks

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,6 @@ fi
 
 INSTALLER_PATH="/usr/local/bin/node_installer"
 
-#mkdir -p /usr/local/bin
-
 cat > "$INSTALLER_PATH" << 'EOF'
 #!/bin/bash
 

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,13 @@ fi || {
   exit 5
 }
 
-echo "Installing"
+tar -tzf "$TARGET".tar.gz >/dev/null
+if [[ "$?" -eq 0 ]] ; then
+  echo "Installing"
+else
+  echo "tar corrupted or not downloaded properly"
+  exit 6
+fi
 tar xzf "$TARGET".tar.gz
 rm -rf "$TARGET".tar.gz
 cp -r "$TARGET"/bin/node /usr/local/bin/

--- a/install.sh
+++ b/install.sh
@@ -73,9 +73,9 @@ echo "Downloading"
 export TMP_DIR=$( mktemp -d )
 cd "$TMP_DIR"
 if `which wget > /dev/null` ; then
-  wget -q https://nodejs.org/dist/v"$NODE"/"$TARGET".tar.xz
+  wget -q https://nodejs.org/dist/v"$NODE"/"$TARGET".tar.gz
 elif `which curl > /dev/null` ; then
-  curl -sS -o "$TARGET".tar.xz https://nodejs.org/dist/v"$NODE"/"$TARGET".tar.xz
+  curl -sS -o "$TARGET".tar.gz https://nodejs.org/dist/v"$NODE"/"$TARGET".tar.gz
 else
   echo "wget or curl command not found"
   exit 4
@@ -87,8 +87,8 @@ fi || {
 }
 
 echo "Installing"
-tar xf "$TARGET".tar.xz
-rm -rf "$TARGET".tar.xz
+tar xzf "$TARGET".tar.gz
+rm -rf "$TARGET".tar.gz
 cp -r "$TARGET"/bin/node /usr/local/bin/
 mkdir -p /usr/local/lib
 cp -r "$TARGET"/lib/node_modules /usr/local/lib/


### PR DESCRIPTION
1. The node binaries are downloaded in tgz format.
2. --yarn switch auto installs yarn globally. Independent argument order supported.
3. It supports both x.y.z and vx.y.z formats for node version
4. The tar is not extracted directly to /usr/local/bin/node. Instead a folder with version name is created and the files are symlinked to /usr/local/node. It does not delete the older version, instead keeps it for future use. 
5. The script checks for broken links of globally installed modules. A function is added which deletes them.
