### PR TITLE
Support install files caching

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ while [[ $# != 0 ]] ; do
     exit 3
   elif [[ $1 == --cache ]] ; then
     INSTALL_FILES_CACHE="$2"
-    shift 2
+    shift
   else
     echo "Unknown parameter provided: $1"
     print_help

--- a/install.sh
+++ b/install.sh
@@ -82,11 +82,33 @@ eval set -- "$PARSED_ARGUMENTS"
 while :
 do
   case "$1" in
-    -y | --yarn)  echo "Yarn is always installed. '--yarn' is deprecated." ; shift ;;
-    -n | --npx)   echo "Npx is always installed. '--npx' is deprecated."; shift ;;
-    -c | --cache) INSTALL_FILES_CACHE="$2" ; shift 2 ;;
-    --)           shift; break ;;
-    *) echo "Unexpected option: $1 - this should not happen." ; print_help ; exit 1 ;;
+    -y | --yarn)
+      echo "Yarn is always installed. '--yarn' is deprecated."
+      shift
+      ;;
+
+    -n | --npx)
+      echo "Npx is always installed. '--npx' is deprecated."
+      shift
+      ;;
+
+    -c | --cache)
+      INSTALL_FILES_CACHE="$2"
+      echo "Caching fetched install files. Path to cache: $INSTALL_FILES_CACHE"
+      shift 2
+      ;;
+
+    --)
+      shift
+      break
+      ;;
+
+    *)
+      echo "Unexpected option: $1 - this should not happen."
+      print_help
+      exit 1
+      ;;
+
   esac
 done
 

--- a/install.sh
+++ b/install.sh
@@ -72,12 +72,14 @@ NPX=false
 RM_NPX=":"
 INSTALL_FILES_CACHE=
 
+set +e
 PARSED_ARGUMENTS=$(getopt -n node_installer -o ync: --long yarn,npx,cache: -- "$@")
 VALID_ARGUMENTS=$?
 if [ "$VALID_ARGUMENTS" != "0" ]; then
   print_help
   exit 1
 fi
+set -e
 
 eval set -- "$PARSED_ARGUMENTS"
 while :

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,6 @@ clean_previous_installations() {
 download() {
   echo "Downloading"
 
-  cd "$TMP_DIR"
   if `which wget > /dev/null` ; then
     wget -q https://nodejs.org/dist/"$NODE"/"$TARGET".tar.gz
   elif `which curl > /dev/null` ; then
@@ -135,10 +134,11 @@ clean_previous_installations
 export TMP_DIR=$( mktemp -d )
 
 if [[ -z "$INSTALL_FILES_CACHE" ]] ; then
+  cd "$TMP_DIR"
   download
 else
-  mkdir -p "$INSTALL_FILES_CACHE"
-  cd "$INSTALL_FILES_CACHE"
+  mkdir -p -- "$INSTALL_FILES_CACHE"
+  cd -- "$INSTALL_FILES_CACHE"
   if [[ -f "$TARGET.tar.gz" ]] ; then
     echo "Using $TARGET.tar.gz from cache"
   else
@@ -150,6 +150,7 @@ else
 fi
 
 echo "Installing"
+cd "$TMP_DIR"
 tar xf "$TARGET".tar.gz
 rm -rf "$TARGET".tar.gz
 cp -r "$TARGET"/bin/node /usr/local/bin/


### PR DESCRIPTION
`node_installer` can be run in environment with persistent storage. Allowing to cache fetched install files is faster. More importantly it provides some level of resilience when node is not available for download (networking issue or [nodejs infra issues](https://github.com/nodejs/nodejs.org/issues/5149))