### PR TITLE
Parse arguments manually

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ while [[ "$#" -ne 0 ]] ; do
         echo "Cache path is empty"
         exit 1
       }
-      echo "Caching fetched install files. Path to cache: $INSTALL_FILES_CACHE"
+      echo "Setting cache folder: $INSTALL_FILES_CACHE"
       shift 2
       ;;
 

--- a/install.sh
+++ b/install.sh
@@ -77,15 +77,15 @@ handle_positional_argument() {
   fi
 }
 
+if [[ "$1" == 'help' ]] || [[ -z "$1" ]] ; then
+  print_help
+  exit 0
+fi
+
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root"
    print_help
    exit 1
-fi
-
-if [[ "$1" == 'help' ]] || [[ -z "$1" ]] ; then
-  print_help
-  exit 0
 fi
 
 if [[ "$1" == clean ]] ; then

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,10 @@ while [[ "$#" -ne 0 ]] ; do
   case "$1" in
     -c | --cache)
       INSTALL_FILES_CACHE="$2"
+      [[ -n "${INSTALL_FILES_CACHE}" ]] || {
+        echo "Cache path is empty"
+        exit 1
+      }
       echo "Caching fetched install files. Path to cache: $INSTALL_FILES_CACHE"
       shift 2
       ;;

--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,7 @@ cd /usr/local/bin
 ln -s ../lib/node_modules/npm/bin/npm-cli.js npm
 chmod +x node npm
 
-echo "Linking nxp"
+echo "Linking npx"
 rm -f npx
 ln -s ../lib/node_modules/npm/bin/npx-cli.js npx
 chmod +x npx

--- a/install.sh
+++ b/install.sh
@@ -88,6 +88,11 @@ if [[ "$1" == 'help' ]] || [[ -z "$1" ]] ; then
   exit 0
 fi
 
+if [[ "$1" == clean ]] ; then
+  clean_previous_installations
+  exit 0
+fi
+
 # Defaults for options
 NODE=
 INSTALL_FILES_CACHE=
@@ -128,11 +133,6 @@ fi
 
 if ! [[ $NODE =~ ^v ]] ; then
   NODE=v$NODE
-fi
-
-if [[ "$NODE" == 'vclean' ]] ; then
-  clean_previous_installations "$RM_YARN" "$RM_NPX"
-  exit 0
 fi
 
 if [[ ! "$NODE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then


### PR DESCRIPTION
We want to parse script's arguments manually to get rid of `getopt`. It's not portable and not installed by default on many systems.